### PR TITLE
feat(ui): inline virtual text

### DIFF
--- a/src/nvim/api/extmark.c
+++ b/src/nvim/api/extmark.c
@@ -399,6 +399,8 @@ Array nvim_buf_get_extmarks(Buffer buffer, Integer ns_id, Object start, Object e
 ///                 - "overlay": display over the specified column, without
 ///                              shifting the underlying text.
 ///                 - "right_align": display right aligned in the window.
+///                 - "inline": display at the specified column, and
+///                              shift the buffer text to the right as needed
 ///               - virt_text_win_col : position the virtual text at a fixed
 ///                                     window column (starting from the first
 ///                                     text column)
@@ -613,6 +615,8 @@ Integer nvim_buf_set_extmark(Buffer buffer, Integer ns_id, Integer line, Integer
       decor.virt_text_pos = kVTOverlay;
     } else if (strequal("right_align", str.data)) {
       decor.virt_text_pos = kVTRightAlign;
+    } else if (strequal("inline", str.data)) {
+      decor.virt_text_pos = kVTInline;
     } else {
       api_set_error(err, kErrorTypeValidation, "virt_text_pos: invalid value");
       goto error;

--- a/src/nvim/decoration.h
+++ b/src/nvim/decoration.h
@@ -15,9 +15,10 @@ typedef enum {
   kVTOverlay,
   kVTWinCol,
   kVTRightAlign,
+  kVTInline,
 } VirtTextPos;
 
-EXTERN const char *const virt_text_pos_str[] INIT(= { "eol", "overlay", "win_col", "right_align" });
+EXTERN const char *const virt_text_pos_str[] INIT(= { "eol", "overlay", "win_col", "right_align", "inline" });
 
 typedef enum {
   kHlModeUnknown,

--- a/src/nvim/plines.c
+++ b/src/nvim/plines.c
@@ -296,8 +296,16 @@ void init_chartabsize_arg(chartabsize_T *cts, win_T *wp, linenr_T lnum FUNC_ATTR
   cts->cts_line = line;
   cts->cts_ptr = ptr;
   cts->cts_cur_text_width = 0;
-  // TODO(bfredl): actually lookup inline virtual text here
   cts->cts_has_virt_text = false;
+  cts->cts_row = lnum - 1;
+
+  if (cts->cts_row >= 0) {
+    marktree_itr_get(wp->w_buffer->b_marktree, cts->cts_row, 0, cts->cts_iter);
+    mtkey_t mark = marktree_itr_current(cts->cts_iter);
+    if (mark.pos.row == lnum-1) {
+      cts->cts_has_virt_text = true;
+    }
+  }
 }
 
 /// Free any allocated item in "cts".
@@ -379,7 +387,23 @@ int win_lbr_chartabsize(chartabsize_T *cts, int *headp)
   // First get normal size, without 'linebreak' or virtual text
   int size = win_chartabsize(wp, (char *)s, vcol);
   if (cts->cts_has_virt_text) {
-    // TODO(bfredl): inline virtual text
+    int col = (int)((char *)s - line);
+    while (true) {
+      mtkey_t mark = marktree_itr_current(cts->cts_iter);
+      if (mark.pos.row != cts->cts_row || mark.pos.col > col) {
+        break;
+      } else if (mark.pos.col == col) { // TODO: or maybe unconditionally, what if byte-misaligned?
+        if (!mt_end(mark)) {
+          Decoration decor = get_decor(mark);
+          if (decor.virt_text_pos == kVTInline) {
+            cts->cts_cur_text_width = decor.virt_text_width;
+            size += cts->cts_cur_text_width;
+          }
+        }
+
+      }
+      marktree_itr_next(wp->w_buffer->b_marktree, cts->cts_iter);
+    }
   }
 
   int c = *s;

--- a/src/nvim/plines.h
+++ b/src/nvim/plines.h
@@ -8,9 +8,11 @@ typedef struct {
   win_T *cts_win;
   char *cts_line;    // start of the line
   char *cts_ptr;     // current position in line
+  int cts_row;
 
   bool cts_has_virt_text;  // true if if a property inserts text
   int cts_cur_text_width;     // width of current inserted text
+  MarkTreeIter cts_iter[1];
   // TODO(bfredl): iterator in to the marktree for scanning virt text
 
   int cts_vcol;    // virtual column at current position

--- a/test/functional/ui/decorations_spec.lua
+++ b/test/functional/ui/decorations_spec.lua
@@ -564,6 +564,7 @@ describe('extmark decorations', function()
       [24] = {bold = true};
       [25] = {background = Screen.colors.LightRed};
       [26] = {background=Screen.colors.DarkGrey, foreground=Screen.colors.LightGrey};
+      [27] = {foreground = Screen.colors.SlateBlue};
     }
 
     ns = meths.create_namespace 'test'
@@ -958,6 +959,85 @@ end]]
         {1:~                                                 }|
                                                           |
       ]])
+  end)
+
+  it('can have virtual text of inline position', function()
+    insert(example_text)
+    feed 'gg'
+    screen:expect{grid=[[
+      ^for _,item in ipairs(items) do                    |
+          local text, hl_id_cell, count = unpack(item)  |
+          if hl_id_cell ~= nil then                     |
+              hl_id = hl_id_cell                        |
+          end                                           |
+          for _ = 1, (count or 1) do                    |
+              local cell = line[colpos]                 |
+              cell.text = text                          |
+              cell.hl_id = hl_id                        |
+              colpos = colpos+1                         |
+          end                                           |
+      end                                               |
+      {1:~                                                 }|
+      {1:~                                                 }|
+                                                        |
+    ]]}
+
+    meths.buf_set_extmark(0, ns, 1, 14, {virt_text={{': ', 'Special'}, {'string', 'Type'}}, virt_text_pos='inline'})
+    screen:expect{grid=[[
+      ^for _,item in ipairs(items) do                    |
+          local text{27:: }{3:string}, hl_id_cell, count = unpack|
+      (item)                                            |
+          if hl_id_cell ~= nil then                     |
+              hl_id = hl_id_cell                        |
+          end                                           |
+          for _ = 1, (count or 1) do                    |
+              local cell = line[colpos]                 |
+              cell.text = text                          |
+              cell.hl_id = hl_id                        |
+              colpos = colpos+1                         |
+          end                                           |
+      end                                               |
+      {1:~                                                 }|
+                                                        |
+    ]]}
+
+    screen:try_resize(55, 15)
+    screen:expect{grid=[[
+      ^for _,item in ipairs(items) do                         |
+          local text{27:: }{3:string}, hl_id_cell, count = unpack(item|
+      )                                                      |
+          if hl_id_cell ~= nil then                          |
+              hl_id = hl_id_cell                             |
+          end                                                |
+          for _ = 1, (count or 1) do                         |
+              local cell = line[colpos]                      |
+              cell.text = text                               |
+              cell.hl_id = hl_id                             |
+              colpos = colpos+1                              |
+          end                                                |
+      end                                                    |
+      {1:~                                                      }|
+                                                             |
+    ]]}
+
+    screen:try_resize(56, 15)
+    screen:expect{grid=[[
+      ^for _,item in ipairs(items) do                          |
+          local text{27:: }{3:string}, hl_id_cell, count = unpack(item)|
+          if hl_id_cell ~= nil then                           |
+              hl_id = hl_id_cell                              |
+          end                                                 |
+          for _ = 1, (count or 1) do                          |
+              local cell = line[colpos]                       |
+              cell.text = text                                |
+              cell.hl_id = hl_id                              |
+              colpos = colpos+1                               |
+          end                                                 |
+      end                                                     |
+      {1:~                                                       }|
+      {1:~                                                       }|
+                                                              |
+    ]]}
   end)
 end)
 


### PR DESCRIPTION
vim-patch:9.0.0067: cannot show virtual text

Problem:    Cannot show virtual text.
Solution:   Initial changes for virtual text support, using text properties.    https://github.com/vim/vim/commit/7f9969c559b51446632ac7e8f76cde07e7d0078d

vim-patch:9.0.0116: virtual text not displayed if 'signcolumn' is "yes"

Problem:    Virtual text not displayed if 'signcolumn' is "yes".
Solution:   Set c_extra and c_final to NUL.
https://github.com/vim/vim/commit/711483cd1381a4ed848d783ae0a6792d5b04447b